### PR TITLE
1 all articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -4629,6 +4631,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -8172,6 +8196,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoopy": {
@@ -13638,6 +13670,30 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -19629,6 +19685,27 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
     },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -22207,6 +22284,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -25992,6 +26077,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,2 +1,3 @@
 .App {
+  padding: 0.5rem;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,22 @@
+import { Route, Routes } from "react-router-dom";
+
+import Header from "./components/Header";
+import Articles from "./components/Articles";
+import Footer from "./components/Footer";
+
 import "./App.css";
 
 function App() {
-  return <div className="App"></div>;
+  return (
+    <div className="App">
+      <Header />
+      <Routes>
+        <Route path="/" element={<Articles />} />
+        <Route path="/all" element={<Articles />} />
+      </Routes>
+      <Footer />
+    </div>
+  );
 }
 
 export default App;

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,3 @@
+export const fetchArticles = () => {
+  return ["stop trying to make fetch happen"];
+};

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,3 +1,11 @@
-export const fetchArticles = () => {
-  return ["stop trying to make fetch happen"];
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: "https://akflds-news-api.herokuapp.com/api",
+});
+
+export const getArticles = () => {
+  return api.get("/articles").then(({ data }) => {
+    return data.articles;
+  });
 };

--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -4,11 +4,16 @@ const ArticleCard = ({ title, author, topic, votes, comment_count }) => {
   return (
     <article className={styles.articleCard}>
       <h3>{title}</h3>
-      <p>Author: {author}</p>
-      <p>Posted in {topic}</p>
-      <p>
-        Votes: {votes}. Comments: {comment_count}
-      </p>
+      <div className={styles.articleInfo}>
+        <p>Author: {author}</p>
+        <p>
+          Posted under <span className={styles.topic}>{topic}</span>
+        </p>
+      </div>
+      <div className={styles.articleStats}>
+        <p>Votes: {votes}</p>
+        <p>Comments: {comment_count}</p>
+      </div>
     </article>
   );
 };

--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -1,7 +1,14 @@
-const ArticleCard = ({ title }) => {
+import styles from "./ArticleCard.module.css";
+
+const ArticleCard = ({ title, author, topic, votes, comment_count }) => {
   return (
-    <article>
+    <article className={styles.articleCard}>
       <h3>{title}</h3>
+      <p>Author: {author}</p>
+      <p>Posted in {topic}</p>
+      <p>
+        Votes: {votes}. Comments: {comment_count}
+      </p>
     </article>
   );
 };

--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -1,0 +1,9 @@
+const ArticleCard = ({ title }) => {
+  return (
+    <article>
+      <h3>{title}</h3>
+    </article>
+  );
+};
+
+export default ArticleCard;

--- a/src/components/ArticleCard.module.css
+++ b/src/components/ArticleCard.module.css
@@ -1,0 +1,3 @@
+.articleCard {
+  border: 2px solid var(--border);
+}

--- a/src/components/ArticleCard.module.css
+++ b/src/components/ArticleCard.module.css
@@ -1,3 +1,15 @@
 .articleCard {
   border: 2px solid var(--border);
+  padding: 0.5rem;
+}
+
+.articleInfo,
+.articleStats {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.articleInfo .topic {
+  font-weight: bold;
 }

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,0 +1,5 @@
+const Articles = () => {
+  return <h2>hello, this is articles</h2>;
+};
+
+export default Articles;

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -8,17 +8,20 @@ import styles from "./Articles.module.css";
 
 const Articles = () => {
   const [articles, setArticles] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     getArticles()
       .then((fetchedArticles) => {
         setArticles(fetchedArticles);
+        setIsLoading(false);
       })
       .catch((error) => {
         console.log(error);
       });
   }, []);
 
+  if (isLoading) return <p>Loading...</p>;
   return (
     <section>
       <h2>Latest articles</h2>

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,5 +1,10 @@
 import { useState, useEffect } from "react";
+
+import ArticleCard from "./ArticleCard";
+
 import { getArticles } from "../api/api";
+
+import styles from "./Articles.module.css";
 
 const Articles = () => {
   const [articles, setArticles] = useState([]);
@@ -15,14 +20,14 @@ const Articles = () => {
   }, []);
 
   return (
-    <>
+    <section>
       <h2>Latest articles</h2>
-      <ul>
+      <div className={styles.articlesContainer}>
         {articles.map(({ article_id, title }) => {
-          return <li key={article_id}>{title}</li>;
+          return <ArticleCard key={article_id} title={title} />;
         })}
-      </ul>
-    </>
+      </div>
+    </section>
   );
 };
 

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -23,9 +23,20 @@ const Articles = () => {
     <section>
       <h2>Latest articles</h2>
       <div className={styles.articlesContainer}>
-        {articles.map(({ article_id, title }) => {
-          return <ArticleCard key={article_id} title={title} />;
-        })}
+        {articles.map(
+          ({ article_id, title, topic, author, votes, comment_count }) => {
+            return (
+              <ArticleCard
+                key={article_id}
+                title={title}
+                topic={topic}
+                author={author}
+                votes={votes}
+                comment_count={comment_count}
+              />
+            );
+          }
+        )}
       </div>
     </section>
   );

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,25 +1,25 @@
 import { useState, useEffect } from "react";
-import { fetchArticles } from "../api/api";
+import { getArticles } from "../api/api";
 
 const Articles = () => {
   const [articles, setArticles] = useState([]);
 
   useEffect(() => {
-    setArticles(fetchArticles());
-    // .then((fetchedArticles) => {
-    //   setArticles(fetchedArticles);
-    // })
-    // .catch((error) => {
-    //   console.log(error);
-    // });
+    getArticles()
+      .then((fetchedArticles) => {
+        setArticles(fetchedArticles);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
   }, []);
 
   return (
     <>
       <h2>Latest articles</h2>
       <ul>
-        {articles.map((article) => {
-          return <li>{article}</li>;
+        {articles.map(({ article_id, title }) => {
+          return <li key={article_id}>{title}</li>;
         })}
       </ul>
     </>

--- a/src/components/Articles.jsx
+++ b/src/components/Articles.jsx
@@ -1,5 +1,29 @@
+import { useState, useEffect } from "react";
+import { fetchArticles } from "../api/api";
+
 const Articles = () => {
-  return <h2>hello, this is articles</h2>;
+  const [articles, setArticles] = useState([]);
+
+  useEffect(() => {
+    setArticles(fetchArticles());
+    // .then((fetchedArticles) => {
+    //   setArticles(fetchedArticles);
+    // })
+    // .catch((error) => {
+    //   console.log(error);
+    // });
+  }, []);
+
+  return (
+    <>
+      <h2>Latest articles</h2>
+      <ul>
+        {articles.map((article) => {
+          return <li>{article}</li>;
+        })}
+      </ul>
+    </>
+  );
 };
 
 export default Articles;

--- a/src/components/Articles.module.css
+++ b/src/components/Articles.module.css
@@ -1,0 +1,2 @@
+.articlesContainer {
+}

--- a/src/components/Articles.module.css
+++ b/src/components/Articles.module.css
@@ -1,2 +1,5 @@
 .articlesContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,9 @@
 const Footer = () => {
-  return <p>Feet go here</p>;
+  return (
+    <footer>
+      <p>Feet go here</p>
+    </footer>
+  );
 };
 
 export default Footer;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 const Footer = () => {
   return (
     <footer>
-      <p>Feet go here</p>
+      <p>All the foots will go here</p>
     </footer>
   );
 };

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,5 @@
+const Footer = () => {
+  return <p>Feet go here</p>;
+};
+
+export default Footer;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,9 @@
 const Header = () => {
-  return <h1>NC News</h1>;
+  return (
+    <header>
+      <h1>NC News</h1>
+    </header>
+  );
 };
 
 export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,5 @@
+const Header = () => {
+  return <h1>NC News</h1>;
+};
+
+export default Header;

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,19 @@
+:root {
+  --text: black;
+  --bg: white;
+  --border: black;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { BrowserRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
This adds:

* Initial routes for `/` and `/all` to generate a full list of articles
* Persistent `Header` and `Footer` components 
* API util to fetch all articles
* `Articles` component which makes the article request 
* `ArticleCard` to display initial article information
* Relevant CSS modules

Note: Styling has been kept to a minimum but works well on mobile and desktop. Majority of styling will come when further components are implemented (see tldr wireframes for the end goal...)